### PR TITLE
Correctly assemble error message

### DIFF
--- a/codegen/schema/get-gql-schema.mjs
+++ b/codegen/schema/get-gql-schema.mjs
@@ -25,9 +25,12 @@ export async function getGqlSchema ({ moduleName, cache, url, token }) {
     )
 
     const { data: schema, errors } = await response.json()
-    
+
     if (errors) {
-      throw new Error(errors)
+      throw new Error(errors
+        .map(err => "- " + err.message)
+        .join('\n')
+      )
     }
 
     return { moduleName, cache, schema }


### PR DESCRIPTION
Otherwise it will just print `[object Object]`