### PR TITLE
add cause property to graphql error logs

### DIFF
--- a/src/GraphQL/Client/Query.js
+++ b/src/GraphQL/Client/Query.js
@@ -1,0 +1,3 @@
+export function cause(err) {
+  return String(err.cause || "");
+}

--- a/src/GraphQL/Client/Query.js
+++ b/src/GraphQL/Client/Query.js
@@ -1,3 +1,17 @@
-export function cause(err) {
-  return String(err.cause || "");
-}
+const formatError = (err) => {
+  if (!err) return "";
+  const props = ["message", "code", "syscall", "hostname", "address", "port"]
+    .filter((k) => err[k])
+    .map((k) => `${k}: ${err[k]}`);
+  if (err.cause) props.push(`cause: ${formatError(err.cause)}`);
+  return props.join(", ");
+};
+
+export const cause = (err) => {
+  const c = err.cause;
+  if (!c) return "";
+  if (c instanceof AggregateError) {
+    return [c.message, ...Array.from(c.errors, (e, i) => `[${i}] ${formatError(e)}`)].join("\n");
+  }
+  return formatError(c);
+};

--- a/src/GraphQL/Client/Query.js
+++ b/src/GraphQL/Client/Query.js
@@ -11,7 +11,10 @@ export const cause = (err) => {
   const c = err.cause;
   if (!c) return "";
   if (c instanceof AggregateError) {
-    return [c.message, ...Array.from(c.errors, (e, i) => `[${i}] ${formatError(e)}`)].join("\n");
+    return [
+      c.message,
+      ...Array.from(c.errors, (e, i) => `[${i}] ${formatError(e)}`),
+    ].join("\n");
   }
   return formatError(c);
 };

--- a/src/GraphQL/Client/Query.purs
+++ b/src/GraphQL/Client/Query.purs
@@ -43,6 +43,8 @@ import GraphQL.Client.Types (class GqlQuery, class QueryClient, Client(..), GqlR
 import GraphQL.Client.Variables (class VarsTypeChecked, getVarsJson, getVarsTypeNames)
 import Type.Proxy (Proxy(..))
 
+foreign import cause :: Error -> String
+
 -- | Run a graphQL query with a custom decoder and custom options
 queryOptsWithDecoder
   :: forall client directives schema query returns queryOpts mutationOpts sr
@@ -261,6 +263,8 @@ addErrorInfo schema queryName q =
           <> show queryName
           <> ".\nerror: "
           <> message err
+          <> ".\ncause: "
+          <> cause err
           <> ".\nquery: "
           <> queryName
           <> " "


### PR DESCRIPTION
We are getting `fetch failed` errors in Lambdas. We can log the `cause` property of the error to get more info with fetch