### PR TITLE
Add optional operationTypeHeader to Apollo client options

### DIFF
--- a/src/GraphQL/Client/BaseClients/Apollo.js
+++ b/src/GraphQL/Client/BaseClients/Apollo.js
@@ -2,7 +2,6 @@ import { createClient as createWsClient } from "graphql-ws";
 import {
   gql,
   split,
-  HttpLink,
   createHttpLink,
   InMemoryCache,
   ApolloClient,
@@ -10,6 +9,37 @@ import {
 import { getMainDefinition } from "@apollo/client/utilities/index.js";
 import { setContext } from "@apollo/client/link/context/index.js";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions/index.js";
+
+// Build the HTTP link. When opts.operationTypeHeader is set, requests are
+// split by operation type and the type ("query" or "mutation") is sent as
+// the value of that header, so eg. a load balancer can route queries to a
+// read replica.
+const mkHttpLink = function (opts) {
+  if (!opts.operationTypeHeader) {
+    return createHttpLink({
+      uri: opts.url,
+    });
+  }
+
+  const linkForOperationType = function (operationType) {
+    return createHttpLink({
+      uri: opts.url,
+      headers: { [opts.operationTypeHeader]: operationType },
+    });
+  };
+
+  return split(
+    function ({ query }) {
+      const definition = getMainDefinition(query);
+      return (
+        definition.kind === "OperationDefinition" &&
+        definition.operation === "query"
+      );
+    },
+    linkForOperationType("query"),
+    linkForOperationType("mutation"),
+  );
+};
 
 const createClientWithoutWebsockets = function (opts) {
   const authLink = setContext(function (_, { headers }) {
@@ -25,9 +55,7 @@ const createClientWithoutWebsockets = function (opts) {
     };
   });
 
-  const httpLink = createHttpLink({
-    uri: opts.url,
-  });
+  const httpLink = mkHttpLink(opts);
 
   return new ApolloClient({
     link: authLink.concat(httpLink),
@@ -40,13 +68,7 @@ const createClientWithoutWebsockets = function (opts) {
 };
 
 const createClientWithWebsockets = function (opts) {
-  const httpLink = new HttpLink({
-    uri: opts.url,
-    options: {
-      authToken: opts.authToken,
-      reconnect: true,
-    },
-  });
+  const httpLink = mkHttpLink(opts);
 
   const wsLink = new GraphQLWsLink(
     createWsClient({

--- a/src/GraphQL/Client/BaseClients/Apollo.purs
+++ b/src/GraphQL/Client/BaseClients/Apollo.purs
@@ -1,13 +1,17 @@
 -- | Creates GraphQL Apollo clients
 module GraphQL.Client.BaseClients.Apollo
   ( ApolloClientOptions
+  , ApolloClientOptions'
   , ApolloSubClientOptions
+  , ApolloSubClientOptions'
   , ApolloClient
   , ApolloSubClient
   , MutationOpts
   , QueryOpts
   , createClient
+  , createClient'
   , createSubscriptionClient
+  , createSubscriptionClient'
   , class IsApollo
   , updateCacheJson
   , updateCache
@@ -45,11 +49,35 @@ type ApolloClientOptions =
   , headers :: Array RequestHeader
   }
 
+-- | As `ApolloClientOptions`, plus `operationTypeHeader`: when set, HTTP
+-- | requests include the GraphQL operation type ("query" or "mutation") as
+-- | the value of the header with this name, so eg. a load balancer can route
+-- | queries to a read replica.
+type ApolloClientOptions' =
+  { url :: URL
+  , authToken :: Maybe String
+  , headers :: Array RequestHeader
+  , operationTypeHeader :: Maybe String
+  }
+
 type ApolloSubClientOptions =
   { url :: URL
   , websocketUrl :: URL
   , authToken :: Maybe String
   , headers :: Array RequestHeader
+  }
+
+-- | As `ApolloSubClientOptions`, plus `operationTypeHeader`: when set, HTTP
+-- | requests include the GraphQL operation type ("query" or "mutation") as
+-- | the value of the header with this name, so eg. a load balancer can route
+-- | queries to a read replica. Subscriptions go over the websocket and are
+-- | unaffected (custom headers are not supported in websockets).
+type ApolloSubClientOptions' =
+  { url :: URL
+  , websocketUrl :: URL
+  , authToken :: Maybe String
+  , headers :: Array RequestHeader
+  , operationTypeHeader :: Maybe String
   }
 
 -- | Apollo client to make graphQL queries and mutations.
@@ -91,34 +119,52 @@ createClient
   :: forall schema
    . ApolloClientOptions
   -> Effect (Client ApolloClient schema)
-createClient = clientOptsToForeign >>> createClientImpl >>> map Client
+createClient { url, authToken, headers } =
+  createClient' { url, authToken, headers, operationTypeHeader: Nothing }
+
+createClient'
+  :: forall schema
+   . ApolloClientOptions'
+  -> Effect (Client ApolloClient schema)
+createClient' = clientOptsToForeign >>> createClientImpl >>> map Client
 
 createSubscriptionClient
   :: forall schema
    . ApolloSubClientOptions
   -> Effect (Client ApolloSubClient schema)
-createSubscriptionClient = clientOptsToForeign >>> createSubscriptionClientImpl >>> map Client
+createSubscriptionClient { url, websocketUrl, authToken, headers } =
+  createSubscriptionClient' { url, websocketUrl, authToken, headers, operationTypeHeader: Nothing }
+
+createSubscriptionClient'
+  :: forall schema
+   . ApolloSubClientOptions'
+  -> Effect (Client ApolloSubClient schema)
+createSubscriptionClient' = clientOptsToForeign >>> createSubscriptionClientImpl >>> map Client
 
 clientOptsToForeign
   :: forall r
    . { authToken :: Maybe String
      , headers :: Array RequestHeader
+     , operationTypeHeader :: Maybe String
      | r
      }
   -> { authToken :: Nullable String
      , headers :: Object String
+     , operationTypeHeader :: Nullable String
      | r
      }
 clientOptsToForeign opts =
   opts
     { authToken = toNullable opts.authToken
     , headers = Object.fromFoldable $ opts.headers <#> \h -> Tuple (name h) (value h)
+    , operationTypeHeader = toNullable opts.operationTypeHeader
     }
 
 type ApolloClientOptionsForeign =
   { url :: URL
   , authToken :: Nullable String
   , headers :: Object String
+  , operationTypeHeader :: Nullable String
   }
 
 type ApolloSubApolloClientOptionsForeign =
@@ -126,6 +172,7 @@ type ApolloSubApolloClientOptionsForeign =
   , websocketUrl :: URL
   , authToken :: Nullable String
   , headers :: Object String
+  , operationTypeHeader :: Nullable String
   }
 
 instance queryClient ::

--- a/src/GraphQL/Client/Query.js
+++ b/src/GraphQL/Client/Query.js
@@ -1,0 +1,3 @@
+export function cause(err) {
+  return String(err.cause || "");
+}

--- a/src/GraphQL/Client/Query.js
+++ b/src/GraphQL/Client/Query.js
@@ -1,3 +1,17 @@
-export function cause(err) {
-  return String(err.cause || "");
-}
+const formatError = (err) => {
+  if (!err) return "";
+  const props = ["message", "code", "syscall", "hostname", "address", "port"]
+    .filter((k) => err[k])
+    .map((k) => `${k}: ${err[k]}`);
+  if (err.cause) props.push(`cause: ${formatError(err.cause)}`);
+  return props.join(", ");
+};
+
+export const cause = (err) => {
+  const c = err.cause;
+  if (!c) return "";
+  if (c instanceof AggregateError) {
+    return [c.message, ...Array.from(c.errors, (e, i) => `[${i}] ${formatError(e)}`)].join("\n");
+  }
+  return formatError(c);
+};

--- a/src/GraphQL/Client/Query.js
+++ b/src/GraphQL/Client/Query.js
@@ -11,7 +11,10 @@ export const cause = (err) => {
   const c = err.cause;
   if (!c) return "";
   if (c instanceof AggregateError) {
-    return [c.message, ...Array.from(c.errors, (e, i) => `[${i}] ${formatError(e)}`)].join("\n");
+    return [
+      c.message,
+      ...Array.from(c.errors, (e, i) => `[${i}] ${formatError(e)}`),
+    ].join("\n");
   }
   return formatError(c);
 };

--- a/src/GraphQL/Client/Query.purs
+++ b/src/GraphQL/Client/Query.purs
@@ -43,6 +43,8 @@ import GraphQL.Client.Types (class GqlQuery, class QueryClient, Client(..), GqlR
 import GraphQL.Client.Variables (class VarsTypeChecked, getVarsJson, getVarsTypeNames)
 import Type.Proxy (Proxy(..))
 
+foreign import cause :: Error -> String
+
 -- | Run a graphQL query with a custom decoder and custom options
 queryOptsWithDecoder
   :: forall client directives schema query returns queryOpts mutationOpts sr
@@ -261,6 +263,8 @@ addErrorInfo schema queryName q =
           <> show queryName
           <> ".\nerror: "
           <> message err
+          <> ".\ncause: "
+          <> cause err
           <> ".\nquery: "
           <> queryName
           <> " "


### PR DESCRIPTION
## Summary

Adds an opt-in `operationTypeHeader :: Maybe String` option to the Apollo base clients. When set, HTTP requests carry the GraphQL operation type (`query` or `mutation`) as the value of the given header, so infrastructure (e.g. a load balancer) can route queries to a read replica.

- New `createClient'` / `createSubscriptionClient'` constructors taking `ApolloClientOptions'` / `ApolloSubClientOptions'` with the extra field.
- Existing `createClient` / `createSubscriptionClient` are unchanged (they delegate with `Nothing`), so this is fully backwards compatible.
- When the option is set, the HTTP link is split per operation type with a static header on each branch (same pattern as splitting on subscriptions). Subscriptions go over the websocket and are unaffected, as custom headers are not supported in websockets.

When the option is not set, behaviour is identical to before (no extra header).

---
🤖 This PR was generated by an AI agent (Claude Code) on behalf of Justin Garcia.